### PR TITLE
Pass  to the uboot_compile.sh call

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -225,7 +225,7 @@ if [ $OPTION = "0" -o $OPTION = "1" ]; then
         fi
         if [ ! -f $ROOT/output/uboot/u-boot-sunxi-with-spl.bin-$PLATFORM ]; then
             cd $SCRIPTS
-                ./uboot_compile.sh
+                ./uboot_compile.sh $PLATFORM
                 cd -
         fi
 


### PR DESCRIPTION
I'm trying to create an image for OrangePi PC Plus with mainline kernel using the  OrangePi_Build/Build_OrangePi.sh script and it fails on when tries to compile uboot with the following error message:
`Usage: ./uboot_compile.sh <clean|one|pc|pc-plus|plus|plus2e|lite|2|zeroplus2_h3>
` 
This PR solves that issue for me